### PR TITLE
docs: include references for gathering the correct codecov token

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following is an example `job` that requires that the `test` job completes fi
 Two important notes about the API tokens this action relies on:
 
 1. The `github_token` input is used to create a status check on PRs/commits and report the health score using this GitHub API. Therefore, this token must have `checks: write` permission. As you can see in the above example workflow YAML, this is explicitly provided to the job via `permissions: checks: write`.
-2. The `codecov_token` input is used to _retrieve_ code coverage details from codecov.io. You _cannot_ use the CodeCov "Global Upload" token as it has insufficient permissions to access CodeCov's HTTP API. You _must_ use a human-generated API token for this input.
+2. The `codecov_token` input is used to _retrieve_ code coverage details from codecov.io. You _cannot_ use the CodeCov "Global Upload" token as it has insufficient permissions to access CodeCov's HTTP API. You _must_ use [a human-generated API token][codecov-token] for this input.
 
 ## Usage
 
@@ -91,3 +91,5 @@ The score is currently calculated from the following:
 
 - Problematic comments. Comments that include "TODO", "HACK" and "FIXME" tend to signal that some corners were cut and shortcuts taken, which may negatively impact the long-term health of a project.
 - Missing code coverage. While not a perfect metric, code coverage via tests is generally correlated with higher quality.
+
+[codecov-token]: https://docs.codecov.com/reference/overview


### PR DESCRIPTION
### Summary

This PR links to the @codecov reference that can be followed to gather a human-generated API token. Sending this as a change request because it took me more than a minute or so to discover 🔍 

### Notes

Reference: https://docs.codecov.com/reference/overview

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-health-score/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).