### PR TITLE
chore: increase patch versions to the latest instead of bounded ranges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       - "/.api/apis/codecov"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
### Summary

This PR increases patch versions to the latest instead of bounded ranges for updates from the kind @dependabot. Matches `slackapi/bolt-js`:

https://github.com/slackapi/bolt-js/blob/main/.github/dependabot.yml#L15

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-health-score/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
