### PR TITLE
chore: Add .github/CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 #ECCN:Open Source
 #GUSINFO:Open Source,Open Source Workflow
 
-# @slackapi/slack-platform-devxp
+# @slackapi/platform-devxp
 # are code reviewers for all changes in this repo.
 * @slackapi/platform-devxp


### PR DESCRIPTION
### Summary

This pull request adds a `.github/CODEOWNERS` file to adhere to the Salesforce Open Source project requirements. 

I've also added the `@slack/platform-devxp` team for for all files and comments to match our other projects like https://github.com/slackapi/python-slack-sdk.

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-health-score/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
