### PR TITLE
ci(deps): auto-approve / auto-merge dependencies from dependabot

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,29 @@
+name: Merge updates to dependencies
+on:
+  pull_request:
+jobs:
+  dependabot:
+    name: "@dependabot"
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Collect metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Automerge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

Add a GitHub Actions workflow to auto-approve and auto-merge Dependabot pull requests for patch and minor version updates.

This reduces maintenance burden by automatically handling low-risk dependency updates while still requiring manual review for major version bumps.

#### Repository Settings Required

To enable auto-merge functionality, the following repository settings must be configured:

- **Settings → General → Pull Requests**
  - ✅ Allow auto-merge

- **Settings → Branches → `main` branch protection rule**
  - ✅ Require status checks to pass before merging
    - Add required checks: **Build**, **Unit Tests**

- **Settings → Actions → General → Workflow permissions**
  - ✅ Allow GitHub Actions to create and approve pull requests

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).