### PR TITLE
build!: update node runtime to version 24

### DIFF
--- a/.github/workflows/local/local.yml
+++ b/.github/workflows/local/local.yml
@@ -11,8 +11,10 @@ jobs:
     steps:
       - name: Checkout action
         uses: actions/checkout@v4
-      - name: Build action
+      - name: Install dependencies
         run: npm ci
+      - name: Build action
+        run: npm run build
       - name: Healthscore the healthscore
         id: slack-health-score
         uses: ./.

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
 # outputs:
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'heart'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "ncc build src/index.js -o dist --license licenses.txt --source-map",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "local": "act public --eventpath .github/workflows/local/event.json --secret-file .github/workflows/local/.env --platform ubuntu-latest=node:20-buster",
+    "local": "act public --eventpath .github/workflows/local/event.json --secret-file .github/workflows/local/.env --platform ubuntu-latest=node:24-buster",
     "test": "npm run lint && npm run test:node",
     "test:node": "node --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=test/coverage.txt test/*-test.js test/**/*-test.js"
   },
@@ -29,7 +29,7 @@
     "url": "https://github.com/slackapi/slack-health-score/issues"
   },
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=24.0.0",
     "npm": ">=10.2.0"
   },
   "homepage": "https://github.com/slackapi/slack-health-score#readme",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "ncc build src/index.js -o dist --license licenses.txt --source-map",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "local": "act public --eventpath .github/workflows/local/event.json --secret-file .github/workflows/local/.env --platform ubuntu-latest=node:24-buster",
+    "local": "act public --eventpath .github/workflows/local/event.json --secret-file .github/workflows/local/.env --platform ubuntu-latest=node:24",
     "test": "npm run lint && npm run test:node",
     "test:node": "node --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=test/coverage.txt test/*-test.js test/**/*-test.js"
   },


### PR DESCRIPTION
### Summary

This pull request bumps the Node.js runtime version from `20` to `24`.

[GitHub has begun deprecating Node20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and workflows using this action now show deprecation notices. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

Resolves #179

### Requirements <!-- place an `x` in each `[ ]` -->

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-health-score/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).